### PR TITLE
Rename teams to groups

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -55,7 +55,7 @@ func New(version string) func() *schema.Provider {
 				"adaptive_endpoint":      resourceAdaptiveSession(),
 				"adaptive_resource":      resourceAdaptiveResource(),
 				"adaptive_authorization": resourceAdaptiveAuthorization(),
-				"adaptive_team":          resourceAdaptiveTeam(),
+				"adaptive_group":         resourceAdaptiveTeam(),
 				"adaptive_script":        resourceAdaptiveScript(),
 			},
 			ConfigureContextFunc: providerConfigure,

--- a/internal/provider/team.go
+++ b/internal/provider/team.go
@@ -20,7 +20,7 @@ func resourceAdaptiveTeam() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "",
+				Description: "Name of the group. Must be unique.",
 			},
 			"members": {
 				Type: schema.TypeList,
@@ -28,7 +28,15 @@ func resourceAdaptiveTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional:    true,
-				Description: "List of emails to add to the team. They should be  . If empty, the team will be created without members. ",
+				Description: "List of emails to add to the team. If empty, the group will be created without members. ",
+			},
+			"endpoints": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of names of endpoints to add to this group. If empty, the group will be created without endpoints.",
 			},
 		},
 	}
@@ -55,7 +63,20 @@ func resourceAdaptiveTeamCreate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
-	resp, err := client.CreateTeam(ctx, name, &members)
+	_endpoints := d.Get("endpoints").([]interface{})
+	endpoints := make([]string, len(_endpoints))
+	for i, u := range _endpoints {
+		if val, ok := u.(string); !ok {
+			return diag.FromErr(fmt.Errorf("endpoint name must be a string"))
+		} else {
+			if len(val) == 0 {
+				return diag.FromErr(fmt.Errorf("endpoint name cannot be empty"))
+			}
+			endpoints[i] = val
+		}
+	}
+
+	resp, err := client.CreateTeam(ctx, name, &members, &endpoints)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -104,7 +125,20 @@ func resourceAdaptiveTeamUpdate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
-	if _, err := client.UpdateTeam(ctx, &teamID, name, &members); err != nil {
+	_endpoints := d.Get("endpoints").([]interface{})
+	endpoints := make([]string, len(_endpoints))
+	for i, u := range _endpoints {
+		if val, ok := u.(string); !ok {
+			return diag.FromErr(fmt.Errorf("endpoint name must be a string"))
+		} else {
+			if len(val) == 0 {
+				return diag.FromErr(fmt.Errorf("endpoint name cannot be empty"))
+			}
+			endpoints[i] = val
+		}
+	}
+
+	if _, err := client.UpdateTeam(ctx, &teamID, name, &members, &endpoints); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/terraform-client/main.go
+++ b/internal/terraform-client/main.go
@@ -606,11 +606,12 @@ func (c *Client) DeleteScript(ctx context.Context, id, name string) (bool, error
 	return true, nil
 }
 
-func (c *Client) CreateTeam(ctx context.Context, name *string, members *[]string) (*CreateResourceResponse, error) {
+func (c *Client) CreateTeam(ctx context.Context, name *string, members, endpoints *[]string) (*CreateResourceResponse, error) {
 	payloadBuf := bytes.NewBuffer([]byte{})
 	if err := json.NewEncoder(payloadBuf).Encode(map[string]interface{}{
-		"Name":    name,
-		"Members": members,
+		"Name":      name,
+		"Members":   members,
+		"Endpoints": endpoints,
 	}); err != nil {
 		err = fmt.Errorf("failed to json encode request body. err %w", err)
 		return nil, err
@@ -626,12 +627,12 @@ func (c *Client) CreateTeam(ctx context.Context, name *string, members *[]string
 		return nil, err
 	}
 	if response.StatusCode == 409 {
-		return nil, fmt.Errorf("duplicate team with name %s", *name)
+		return nil, fmt.Errorf("duplicate group with name %s", *name)
 	}
 	if response.StatusCode != 200 {
 		decodedMsg, err := decodeError(response)
 		if err != nil {
-			return nil, fmt.Errorf("error creating team %s", *name)
+			return nil, fmt.Errorf("error creating group %s", *name)
 		}
 		return nil, errors.New(decodedMsg)
 	}
@@ -653,7 +654,7 @@ func (c *Client) GetTeam(ctx context.Context, id string) (*CreateResourceRespons
 		return nil, err
 	}
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("error getting team %s", id)
+		return nil, fmt.Errorf("error getting group %s", id)
 	}
 
 	var resp CreateResourceResponse
@@ -663,11 +664,12 @@ func (c *Client) GetTeam(ctx context.Context, id string) (*CreateResourceRespons
 	return &resp, nil
 }
 
-func (c *Client) UpdateTeam(ctx context.Context, id, name *string, members *[]string) (any, error) {
+func (c *Client) UpdateTeam(ctx context.Context, id, name *string, members, endpoints *[]string) (any, error) {
 	payloadBuf := bytes.NewBuffer([]byte{})
 	if err := json.NewEncoder(payloadBuf).Encode(map[string]interface{}{
-		"Name":    name,
-		"Members": members,
+		"Name":      name,
+		"Members":   members,
+		"Endpoints": endpoints,
 	}); err != nil {
 		err = fmt.Errorf("failed to json encode request body. err %w", err)
 		return nil, err
@@ -685,7 +687,7 @@ func (c *Client) UpdateTeam(ctx context.Context, id, name *string, members *[]st
 	if response.StatusCode != 200 {
 		decodedMsg, err := decodeError(response)
 		if err != nil {
-			return nil, fmt.Errorf("error updating team %s", *name)
+			return nil, fmt.Errorf("error updating group %s", *name)
 		}
 		return nil, errors.New(decodedMsg)
 	}
@@ -705,7 +707,7 @@ func (c *Client) DeleteTeam(ctx context.Context, id, name string) (bool, error) 
 	if response.StatusCode != 200 {
 		decodedMsg, err := decodeError(response)
 		if err != nil {
-			return false, fmt.Errorf("error deleting team %s", name)
+			return false, fmt.Errorf("error deleting group %s", name)
 		}
 		return false, errors.New(decodedMsg)
 	}


### PR DESCRIPTION
1. Rename teams to groups
2. Add `endpoints` field to adaptive_group, to create endpoints members from terraform. Example:
```hcl
resource "adaptive_group" "groupwithnoendpoints" {
  name = "13"
  endpoints = ["s1", "02"]
  members = ["ratin+2@adaptive.live", "ratin+1@adaptive.live"]
}
```