### PR TITLE
Chore: Add support for timeout and JIT configurations in endpoint create/update

### DIFF
--- a/internal/terraform-client/main.go
+++ b/internal/terraform-client/main.go
@@ -234,7 +234,7 @@ func (c *Client) DeleteAuthorization(ctx context.Context, authID string) (bool, 
 }
 
 // Sessions
-func (c *Client) CreateSession(ctx context.Context, sessionName, resourceName, authorizationName, clusterName, ttl, sessionType string, users []string) (*CreateSessionResponse, error) {
+func (c *Client) CreateSession(ctx context.Context, sessionName, resourceName, authorizationName, clusterName, ttl, sessionType string, users []string, isJITEnabled bool, accessApprovers []string, timeout string) (*CreateSessionResponse, error) {
 	req := CreateSessionRequest{
 		SessionName:       sessionName,
 		ResourceName:      resourceName,
@@ -243,6 +243,9 @@ func (c *Client) CreateSession(ctx context.Context, sessionName, resourceName, a
 		SessionTTL:        ttl,
 		SessionType:       sessionType,
 		SessionUsers:      users,
+		IsJITEnabled:      isJITEnabled,
+		AccessApprovers:   accessApprovers,
+		Timeout:           timeout,
 	}
 
 	payloadBuf := bytes.NewBuffer([]byte{})
@@ -344,7 +347,7 @@ func (c *Client) ReadSession(sessionID string, waitForStatus bool) (map[string]i
 	return resp, nil
 }
 
-func (c *Client) UpdateSession(sessionID, sessionName, resourceName, authorizationName, clusterName, ttl, sessionType string, users []string) (*UpdateSessionResponse, error) {
+func (c *Client) UpdateSession(sessionID, sessionName, resourceName, authorizationName, clusterName, ttl, sessionType string, users []string, isJITEnabled bool, accessApprovers []string, timeout string) (*UpdateSessionResponse, error) {
 	req := UpdateSessionRequest{
 		SessionName:       sessionName,
 		ResourceName:      resourceName,
@@ -353,6 +356,9 @@ func (c *Client) UpdateSession(sessionID, sessionName, resourceName, authorizati
 		AuthorizationName: authorizationName,
 		SessionTTL:        ttl,
 		SessionUsers:      users,
+		IsJITEnabled:      isJITEnabled,
+		AccessApprovers:   accessApprovers,
+		Timeout:           timeout,
 	}
 	payloadBuf := bytes.NewBuffer([]byte{})
 	if err := json.NewEncoder(payloadBuf).Encode(req); err != nil {

--- a/internal/terraform-client/models.go
+++ b/internal/terraform-client/models.go
@@ -31,8 +31,16 @@ type CreateSessionRequest struct {
 	AuthorizationName string `json:"authorizationName"`
 	SessionTTL        string `json:"sessionTTL"`
 	SessionType       string `json:"sessionType"`
+
 	// List of user emails to add to the endpoint
 	SessionUsers []string `json:"sessionUsers"`
+
+	// endpoint JIT access mode
+	IsJITEnabled    bool     `json:"is_jit_enabled"`
+	AccessApprovers []string `json:"access_approvers"`
+
+	// pause endpoint timeout
+	Timeout string `json:"timeout"`
 }
 
 type CreateSessionResponse struct {


### PR DESCRIPTION
## Summary
This PR contains the changes to add support to create endpoint configurations which consist of `timeout`, `isJITEnabled` and `accessApprovers` fields.