### PR TITLE
Add adaptive_rdp multi-target RDP support

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -26,21 +26,17 @@ The `adaptive_resource` resource allows you to create and manage connections to 
 | `gcp` | Google Cloud Platform |
 | `kubernetes` | Kubernetes cluster |
 | `ssh` | SSH server |
-| `windows` | Windows server (RDP) |
+| `adaptive_rdp` | Windows RDP fleet — multiple targets, per-target credentials, in-browser access |
 | `okta` | Okta identity provider |
-| `azureactivedirectory` | Azure Active Directory |
 | `onelogin` | OneLogin identity provider |
 | `jumpcloud` | JumpCloud directory |
 | `google` | Google Workspace |
-| `msteams` | Microsoft Teams |
 | `datadog` | Datadog monitoring |
 | `splunk` | Splunk logging |
 | `elasticsearch` | Elasticsearch |
-| `coralogix` | Coralogix logging |
-| `syslog` | Syslog server |
 | `rabbitmq` | RabbitMQ message broker |
 | `zerotier` | ZeroTier network |
-| `services` | Generic services (URL list) |
+| `services` | Generic services |
 | `customintegration` | Custom integration |
 
 ## Example Usage
@@ -155,6 +151,38 @@ resource "adaptive_resource" "ssh" {
 }
 ```
 
+### Adaptive RDP (Multi-Target Fleet)
+
+The `adaptive_rdp` type manages a fleet of Windows RDP hosts in a single resource. Each `targets` block is one host with its own credentials; users pick a target from the in-browser desktop picker. `password` is sensitive, `port` defaults to `3389`, and the optional `record` overrides the global session-recording setting per target (omit it to inherit the global setting).
+
+```terraform
+resource "adaptive_resource" "rdp_fleet" {
+  name = "rdp-fleet-01"
+  type = "adaptive_rdp"
+
+  targets {
+    id       = "server-1"
+    name     = "Windows Server 1"
+    host     = "10.0.0.5"
+    port     = 3389
+    username = "administrator"
+    password = var.win1_password
+  }
+
+  targets {
+    id       = "server-2"
+    name     = "Windows Server 2"
+    host     = "10.0.0.6"
+    username = "administrator"
+    password = var.win2_password
+    domain   = "CORP"
+    record   = true
+  }
+
+  tags = ["windows", "production"]
+}
+```
+
 ### Snowflake
 
 ```terraform
@@ -169,248 +197,6 @@ resource "adaptive_resource" "snowflake" {
   schema    = "PUBLIC"
   role      = "ACCOUNTADMIN"
   tags      = ["analytics"]
-}
-```
-
-### CockroachDB
-
-```terraform
-resource "adaptive_resource" "cockroachdb" {
-  name          = "production-cockroachdb"
-  type          = "cockroachdb"
-  host          = "cockroach.example.com"
-  port          = "26257"
-  username      = "admin"
-  password      = var.cockroach_password
-  database_name = "defaultdb"
-  ssl_mode      = "verify-full"
-  root_cert     = file("ca.crt")
-  tags          = ["production", "database"]
-}
-```
-
-### ClickHouse
-
-```terraform
-resource "adaptive_resource" "clickhouse" {
-  name          = "analytics-clickhouse"
-  type          = "clickhouse"
-  host          = "clickhouse.example.com"
-  port          = "9440"
-  username      = "default"
-  password      = var.clickhouse_password
-  database_name = "analytics"
-  ssl_mode      = "require"
-  tags          = ["analytics"]
-}
-```
-
-### Services
-
-```terraform
-resource "adaptive_resource" "services" {
-  name = "internal-services"
-  type = "services"
-  urls = "https://api.internal.com,https://admin.internal.com,https://dashboard.internal.com"
-  tags = ["internal", "web"]
-}
-```
-
-### Okta
-
-```terraform
-resource "adaptive_resource" "okta" {
-  name          = "okta-sso"
-  type          = "okta"
-  domain        = "mycompany.okta.com"
-  client_id     = var.okta_client_id
-  client_secret = var.okta_client_secret
-  tags          = ["identity", "sso"]
-}
-```
-
-### Azure Active Directory
-
-```terraform
-resource "adaptive_resource" "azure_ad" {
-  name          = "azure-ad-integration"
-  type          = "azureactivedirectory"
-  domain        = "mycompany.onmicrosoft.com"
-  tenant_id     = var.azure_tenant_id
-  client_id     = var.azure_client_id
-  client_secret = var.azure_client_secret
-  tags          = ["identity", "azure"]
-}
-```
-
-### OneLogin
-
-```terraform
-resource "adaptive_resource" "onelogin" {
-  name              = "onelogin-sso"
-  type              = "onelogin"
-  domain            = "mycompany.onelogin.com"
-  client_id         = var.onelogin_client_id
-  client_secret     = var.onelogin_client_secret
-  api_client_id     = var.onelogin_api_client_id
-  api_client_secret = var.onelogin_api_client_secret
-  tags              = ["identity", "sso"]
-}
-```
-
-### JumpCloud
-
-```terraform
-resource "adaptive_resource" "jumpcloud" {
-  name          = "jumpcloud-directory"
-  type          = "jumpcloud"
-  domain        = "console.jumpcloud.com"
-  client_id     = var.jumpcloud_client_id
-  client_secret = var.jumpcloud_client_secret
-  api_token     = var.jumpcloud_api_key
-  tags          = ["identity", "directory"]
-}
-```
-
-### Google Workspace
-
-```terraform
-resource "adaptive_resource" "google_workspace" {
-  name          = "google-workspace"
-  type          = "google"
-  domain        = "mycompany.com"
-  client_id     = var.google_client_id
-  client_secret = var.google_client_secret
-  tags          = ["identity", "google"]
-}
-```
-
-### Datadog
-
-```terraform
-resource "adaptive_resource" "datadog" {
-  name       = "datadog-monitoring"
-  type       = "datadog"
-  dd_site    = "datadoghq.com"
-  dd_api_key = var.datadog_api_key
-  tags       = ["monitoring"]
-}
-```
-
-### Splunk
-
-```terraform
-resource "adaptive_resource" "splunk" {
-  name     = "splunk-logging"
-  type     = "splunk"
-  url      = "https://splunk.example.com:8088"
-  token_id = var.splunk_hec_token
-  tags     = ["logging"]
-}
-```
-
-### Elasticsearch
-
-```terraform
-resource "adaptive_resource" "elasticsearch" {
-  name     = "elasticsearch-cluster"
-  type     = "elasticsearch"
-  uri      = "https://elasticsearch.example.com:9200"
-  username = "elastic"
-  password = var.elasticsearch_password
-  index    = "logs"
-  tags     = ["logging", "search"]
-}
-```
-
-### Coralogix
-
-```terraform
-resource "adaptive_resource" "coralogix" {
-  name             = "coralogix-logging"
-  type             = "coralogix"
-  uri              = "https://api.coralogix.com"
-  private_key      = var.coralogix_private_key
-  application_name = "my-application"
-  sub_system_name  = "production"
-  tags             = ["logging"]
-}
-```
-
-### Syslog
-
-```terraform
-resource "adaptive_resource" "syslog" {
-  name     = "syslog-server"
-  type     = "syslog"
-  hostname = "syslog.example.com"
-  port     = "514"
-  protocol = "tcp"
-  tags     = ["logging"]
-}
-```
-
-### RabbitMQ
-
-```terraform
-resource "adaptive_resource" "rabbitmq" {
-  name     = "rabbitmq-broker"
-  type     = "rabbitmq"
-  uri      = "amqp://rabbitmq.example.com:5672"
-  username = "admin"
-  password = var.rabbitmq_password
-  tags     = ["messaging"]
-}
-```
-
-### Microsoft Teams
-
-```terraform
-resource "adaptive_resource" "msteams" {
-  name          = "teams-integration"
-  type          = "msteams"
-  tenant_id     = var.teams_tenant_id
-  client_id     = var.teams_app_id
-  client_secret = var.teams_app_key
-  tags          = ["collaboration"]
-}
-```
-
-### ZeroTier
-
-```terraform
-resource "adaptive_resource" "zerotier" {
-  name       = "zerotier-network"
-  type       = "zerotier"
-  network_id = "1234567890abcdef"
-  api_token  = var.zerotier_api_token
-  tags       = ["networking"]
-}
-```
-
-### Windows (RDP)
-
-```terraform
-resource "adaptive_resource" "windows" {
-  name     = "windows-server"
-  type     = "windows"
-  hostname = "windows.example.com"
-  port     = "3389"
-  username = "Administrator"
-  password = var.windows_password
-  tags     = ["infrastructure", "windows"]
-}
-```
-
-### Custom Integration
-
-```terraform
-resource "adaptive_resource" "custom" {
-  name                 = "custom-app"
-  type                 = "customintegration"
-  image                = "myregistry/myapp:latest"
-  service_account_name = "custom-sa"
-  tags                 = ["custom"]
 }
 ```
 
@@ -483,6 +269,7 @@ resource "adaptive_resource" "postgres_with_secrets" {
 - `database_username` (String) The database username
 - `dd_api_key` (String) The Datadog API key
 - `dd_site` (String) The Datadog site to send data to
+- `default_cluster` (String) The default cluster
 - `default_user` (String) Default user for the Services resource
 - `domain` (String) The domain name for a resource. Used by Google, Okta resource
 - `host` (String) Hostname of the adaptive resource. Used by CockroachDB, Postgres, Mysql, SSH resources
@@ -516,6 +303,7 @@ resource "adaptive_resource" "postgres_with_secrets" {
 - `ssl_mode` (String) The SSL mode to use when connecting to the database. Used by CockroachDB, Postgres, Mysql resources
 - `sub_system_name` (String) The sub system name for the service
 - `tags` (List of String) Optional tags
+- `targets` (Block List) List of RDP targets. Used by the adaptive_rdp resource. Each block is one Windows host with its own credentials. (see [below for nested schema](#nestedblock--targets))
 - `tenant_id` (String) The Azure tenant ID. Used by Azure resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `tls_cert_file` (String) The certificate file to use for the Postgres-like resources.
@@ -528,6 +316,7 @@ resource "adaptive_resource" "postgres_with_secrets" {
 - `urls` (String) Comma-separated list of URLs. Used by Services resource
 - `use_proxy` (Boolean) Whether to use proxy
 - `use_service_account` (Boolean) Whether to use service account for authentication. Used by GCP resource
+- `use_tenant` (Boolean) Whether to use tenant for Azure Active Directory authentication
 - `username` (String) Username for the adaptive resource authentication. Used by CockroachDB, Postgres, Mysql, SSH resources
 - `version` (String) The version
 - `warehouse` (String) The Snowflake warehouse name. Used by Snowflake resource
@@ -536,6 +325,24 @@ resource "adaptive_resource" "postgres_with_secrets" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--targets"></a>
+### Nested Schema for `targets`
+
+Required:
+
+- `host` (String) Hostname or IP of the Windows server.
+- `id` (String) Unique identifier for the target within the fleet.
+- `username` (String) Username to authenticate with the target.
+
+Optional:
+
+- `domain` (String) Optional Windows domain for the target.
+- `name` (String) Human-friendly name shown in the in-browser target picker.
+- `password` (String, Sensitive) Password to authenticate with the target.
+- `port` (Number) RDP port. Defaults to 3389.
+- `record` (Boolean) Per-target session-recording override. If unset, inherits the global recording setting (COLLECT_RDP_RECORDINGS).
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -26,17 +26,22 @@ The `adaptive_resource` resource allows you to create and manage connections to 
 | `gcp` | Google Cloud Platform |
 | `kubernetes` | Kubernetes cluster |
 | `ssh` | SSH server |
+| `rdp_windows` | Windows server (single-target RDP) |
 | `adaptive_rdp` | Windows RDP fleet — multiple targets, per-target credentials, in-browser access |
 | `okta` | Okta identity provider |
+| `azureactivedirectory` | Azure Active Directory |
 | `onelogin` | OneLogin identity provider |
 | `jumpcloud` | JumpCloud directory |
 | `google` | Google Workspace |
+| `msteams` | Microsoft Teams |
 | `datadog` | Datadog monitoring |
 | `splunk` | Splunk logging |
 | `elasticsearch` | Elasticsearch |
+| `coralogix` | Coralogix logging |
+| `syslog` | Syslog server |
 | `rabbitmq` | RabbitMQ message broker |
 | `zerotier` | ZeroTier network |
-| `services` | Generic services |
+| `services` | Generic services (URL list) |
 | `customintegration` | Custom integration |
 
 ## Example Usage
@@ -151,6 +156,20 @@ resource "adaptive_resource" "ssh" {
 }
 ```
 
+### Windows Server (Single-Target RDP)
+
+```terraform
+resource "adaptive_resource" "windows" {
+  name     = "windows-server"
+  type     = "rdp_windows"
+  hostname = "windows.example.com"
+  port     = "3389"
+  username = "Administrator"
+  password = var.windows_password
+  tags     = ["infrastructure", "windows"]
+}
+```
+
 ### Adaptive RDP (Multi-Target Fleet)
 
 The `adaptive_rdp` type manages a fleet of Windows RDP hosts in a single resource. Each `targets` block is one host with its own credentials; users pick a target from the in-browser desktop picker. `password` is sensitive, `port` defaults to `3389`, and the optional `record` overrides the global session-recording setting per target (omit it to inherit the global setting).
@@ -197,6 +216,234 @@ resource "adaptive_resource" "snowflake" {
   schema    = "PUBLIC"
   role      = "ACCOUNTADMIN"
   tags      = ["analytics"]
+}
+```
+
+### CockroachDB
+
+```terraform
+resource "adaptive_resource" "cockroachdb" {
+  name          = "production-cockroachdb"
+  type          = "cockroachdb"
+  host          = "cockroach.example.com"
+  port          = "26257"
+  username      = "admin"
+  password      = var.cockroach_password
+  database_name = "defaultdb"
+  ssl_mode      = "verify-full"
+  root_cert     = file("ca.crt")
+  tags          = ["production", "database"]
+}
+```
+
+### ClickHouse
+
+```terraform
+resource "adaptive_resource" "clickhouse" {
+  name          = "analytics-clickhouse"
+  type          = "clickhouse"
+  host          = "clickhouse.example.com"
+  port          = "9440"
+  username      = "default"
+  password      = var.clickhouse_password
+  database_name = "analytics"
+  ssl_mode      = "require"
+  tags          = ["analytics"]
+}
+```
+
+### Services
+
+```terraform
+resource "adaptive_resource" "services" {
+  name = "internal-services"
+  type = "services"
+  urls = "https://api.internal.com,https://admin.internal.com,https://dashboard.internal.com"
+  tags = ["internal", "web"]
+}
+```
+
+### Okta
+
+```terraform
+resource "adaptive_resource" "okta" {
+  name          = "okta-sso"
+  type          = "okta"
+  domain        = "mycompany.okta.com"
+  client_id     = var.okta_client_id
+  client_secret = var.okta_client_secret
+  tags          = ["identity", "sso"]
+}
+```
+
+### Azure Active Directory
+
+```terraform
+resource "adaptive_resource" "azure_ad" {
+  name          = "azure-ad-integration"
+  type          = "azureactivedirectory"
+  domain        = "mycompany.onmicrosoft.com"
+  tenant_id     = var.azure_tenant_id
+  client_id     = var.azure_client_id
+  client_secret = var.azure_client_secret
+  tags          = ["identity", "azure"]
+}
+```
+
+### OneLogin
+
+```terraform
+resource "adaptive_resource" "onelogin" {
+  name              = "onelogin-sso"
+  type              = "onelogin"
+  domain            = "mycompany.onelogin.com"
+  client_id         = var.onelogin_client_id
+  client_secret     = var.onelogin_client_secret
+  api_client_id     = var.onelogin_api_client_id
+  api_client_secret = var.onelogin_api_client_secret
+  tags              = ["identity", "sso"]
+}
+```
+
+### JumpCloud
+
+```terraform
+resource "adaptive_resource" "jumpcloud" {
+  name          = "jumpcloud-directory"
+  type          = "jumpcloud"
+  domain        = "console.jumpcloud.com"
+  client_id     = var.jumpcloud_client_id
+  client_secret = var.jumpcloud_client_secret
+  api_token     = var.jumpcloud_api_key
+  tags          = ["identity", "directory"]
+}
+```
+
+### Google Workspace
+
+```terraform
+resource "adaptive_resource" "google_workspace" {
+  name          = "google-workspace"
+  type          = "google"
+  domain        = "mycompany.com"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  tags          = ["identity", "google"]
+}
+```
+
+### Datadog
+
+```terraform
+resource "adaptive_resource" "datadog" {
+  name       = "datadog-monitoring"
+  type       = "datadog"
+  dd_site    = "datadoghq.com"
+  dd_api_key = var.datadog_api_key
+  tags       = ["monitoring"]
+}
+```
+
+### Splunk
+
+```terraform
+resource "adaptive_resource" "splunk" {
+  name     = "splunk-logging"
+  type     = "splunk"
+  url      = "https://splunk.example.com:8088"
+  token_id = var.splunk_hec_token
+  tags     = ["logging"]
+}
+```
+
+### Elasticsearch
+
+```terraform
+resource "adaptive_resource" "elasticsearch" {
+  name     = "elasticsearch-cluster"
+  type     = "elasticsearch"
+  uri      = "https://elasticsearch.example.com:9200"
+  username = "elastic"
+  password = var.elasticsearch_password
+  index    = "logs"
+  tags     = ["logging", "search"]
+}
+```
+
+### Coralogix
+
+```terraform
+resource "adaptive_resource" "coralogix" {
+  name             = "coralogix-logging"
+  type             = "coralogix"
+  uri              = "https://api.coralogix.com"
+  private_key      = var.coralogix_private_key
+  application_name = "my-application"
+  sub_system_name  = "production"
+  tags             = ["logging"]
+}
+```
+
+### Syslog
+
+```terraform
+resource "adaptive_resource" "syslog" {
+  name     = "syslog-server"
+  type     = "syslog"
+  hostname = "syslog.example.com"
+  port     = "514"
+  protocol = "tcp"
+  tags     = ["logging"]
+}
+```
+
+### RabbitMQ
+
+```terraform
+resource "adaptive_resource" "rabbitmq" {
+  name     = "rabbitmq-broker"
+  type     = "rabbitmq"
+  uri      = "amqp://rabbitmq.example.com:5672"
+  username = "admin"
+  password = var.rabbitmq_password
+  tags     = ["messaging"]
+}
+```
+
+### Microsoft Teams
+
+```terraform
+resource "adaptive_resource" "msteams" {
+  name          = "teams-integration"
+  type          = "msteams"
+  tenant_id     = var.teams_tenant_id
+  client_id     = var.teams_app_id
+  client_secret = var.teams_app_key
+  tags          = ["collaboration"]
+}
+```
+
+### ZeroTier
+
+```terraform
+resource "adaptive_resource" "zerotier" {
+  name       = "zerotier-network"
+  type       = "zerotier"
+  network_id = "1234567890abcdef"
+  api_token  = var.zerotier_api_token
+  tags       = ["networking"]
+}
+```
+
+### Custom Integration
+
+```terraform
+resource "adaptive_resource" "custom" {
+  name                 = "custom-app"
+  type                 = "customintegration"
+  image                = "myregistry/myapp:latest"
+  service_account_name = "custom-sa"
+  tags                 = ["custom"]
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.7
 toolchain go1.24.2
 
 require (
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
@@ -33,7 +34,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect

--- a/internal/provider/components/resource.go
+++ b/internal/provider/components/resource.go
@@ -39,6 +39,7 @@ var (
 		"awsredshift",
 		"zerotier",
 		"rdp_windows",
+		"adaptive_rdp",
 		"mongodb_atlas",
 		"awssecretsmanager",
 
@@ -525,6 +526,57 @@ func ResourceAdaptiveResource() *schema.Resource {
 				Optional:    true,
 				Description: "Whether to use tenant for Azure Active Directory authentication",
 			},
+			"targets": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of RDP targets. Used by the adaptive_rdp resource. Each block is one Windows host with its own credentials.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Unique identifier for the target within the fleet.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Human-friendly name shown in the in-browser target picker.",
+						},
+						"host": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Hostname or IP of the Windows server.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     3389,
+							Description: "RDP port. Defaults to 3389.",
+						},
+						"username": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Username to authenticate with the target.",
+						},
+						"password": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: "Password to authenticate with the target.",
+						},
+						"domain": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Optional Windows domain for the target.",
+						},
+						"record": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Per-target session-recording override. If unset, inherits the global recording setting (COLLECT_RDP_RECORDINGS).",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -576,6 +628,8 @@ func schemaToResourceIntegrationConfiguration(d *schema.ResourceData, intType st
 		return integrations.SchemaToMongoAtlasIntegrationConfiguration(d), nil
 	case "rdp_windows":
 		return integrations.SchemaToRDPWindowsIntegrationConfiguration(d), nil
+	case "adaptive_rdp":
+		return integrations.SchemaToAdaptiveRDPIntegrationConfiguration(d)
 	case "awssecretsmanager":
 		return integrations.SchemaToAWSSecretsManagerConfiguration(d), nil
 	case "sql_server":

--- a/internal/provider/integrations/adaptive_rdp.go
+++ b/internal/provider/integrations/adaptive_rdp.go
@@ -1,0 +1,110 @@
+package integrations
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"gopkg.in/yaml.v2"
+)
+
+// AdaptiveRDPTargetConfig mirrors TargetConfig in
+// inventorize-app/internal/service/integrations/adaptive_rdp/config.go.
+type AdaptiveRDPTargetConfig struct {
+	ID       string `yaml:"id"`
+	Name     string `yaml:"name,omitempty"`
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+	Domain   string `yaml:"domain,omitempty"`
+	// Record is a tri-state override: nil inherits the global recording
+	// setting, true/false force per-target recording on/off.
+	Record *bool `yaml:"record,omitempty"`
+}
+
+// AdaptiveRDPIntegrationConfiguration mirrors the backend
+// AdaptiveRDPIntegrationConfiguration. Targets is a YAML-encoded list of
+// AdaptiveRDPTargetConfig that the server re-parses via ParseTargets().
+type AdaptiveRDPIntegrationConfiguration struct {
+	Version string `yaml:"version"`
+	Name    string `yaml:"name"`
+	Targets string `yaml:"targets"`
+}
+
+func SchemaToAdaptiveRDPIntegrationConfiguration(d *schema.ResourceData) (AdaptiveRDPIntegrationConfiguration, error) {
+	raw, ok := d.GetOk("targets")
+	if !ok {
+		return AdaptiveRDPIntegrationConfiguration{}, errors.New("adaptive_rdp requires at least one `targets` block")
+	}
+	list, ok := raw.([]interface{})
+	if !ok || len(list) == 0 {
+		return AdaptiveRDPIntegrationConfiguration{}, errors.New("adaptive_rdp requires at least one `targets` block")
+	}
+
+	// `record` is tri-state on the backend (nil = inherit the global
+	// COLLECT_RDP_RECORDINGS setting). The SDK collapses an unset bool to
+	// false via d.Get, so read the raw config to tell "unset" from "false".
+	recordOverrides := adaptiveRDPRecordOverrides(d, len(list))
+
+	targets := make([]AdaptiveRDPTargetConfig, 0, len(list))
+	for i, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			return AdaptiveRDPIntegrationConfiguration{}, errors.New("could not parse `targets` entry")
+		}
+		targets = append(targets, AdaptiveRDPTargetConfig{
+			ID:       m["id"].(string),
+			Name:     m["name"].(string),
+			Host:     m["host"].(string),
+			Port:     m["port"].(int),
+			Username: m["username"].(string),
+			Password: m["password"].(string),
+			Domain:   m["domain"].(string),
+			Record:   recordOverrides[i],
+		})
+	}
+
+	out, err := yaml.Marshal(targets)
+	if err != nil {
+		return AdaptiveRDPIntegrationConfiguration{}, fmt.Errorf("could not marshal `targets`: %w", err)
+	}
+
+	return AdaptiveRDPIntegrationConfiguration{
+		Version: "1.0",
+		Name:    d.Get("name").(string),
+		Targets: string(out),
+	}, nil
+}
+
+// adaptiveRDPRecordOverrides returns a per-target *bool for the `record` field,
+// distinguishing unset (nil) from an explicit true/false by inspecting the raw
+// config — d.Get would report an unset bool as false.
+func adaptiveRDPRecordOverrides(d *schema.ResourceData, n int) []*bool {
+	out := make([]*bool, n)
+
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return out
+	}
+	targets := raw.GetAttr("targets")
+	if targets.IsNull() || !targets.IsKnown() {
+		return out
+	}
+
+	elems := targets.AsValueSlice()
+	for i := 0; i < n && i < len(elems); i++ {
+		e := elems[i]
+		if e.IsNull() || !e.IsKnown() {
+			continue
+		}
+		rec := e.GetAttr("record")
+		if rec.IsNull() || !rec.IsKnown() || rec.Type() != cty.Bool {
+			continue
+		}
+		v := rec.True()
+		out[i] = &v
+	}
+	return out
+}

--- a/internal/provider/integrations/adaptive_rdp.go
+++ b/internal/provider/integrations/adaptive_rdp.go
@@ -38,24 +38,27 @@ func SchemaToAdaptiveRDPIntegrationConfiguration(d *schema.ResourceData) (Adapti
 	if !ok {
 		return AdaptiveRDPIntegrationConfiguration{}, errors.New("adaptive_rdp requires at least one `targets` block")
 	}
-	list, ok := raw.([]interface{})
-	if !ok || len(list) == 0 {
-		return AdaptiveRDPIntegrationConfiguration{}, errors.New("adaptive_rdp requires at least one `targets` block")
-	}
+	list := raw.([]interface{})
 
 	// `record` is tri-state on the backend (nil = inherit the global
 	// COLLECT_RDP_RECORDINGS setting). The SDK collapses an unset bool to
 	// false via d.Get, so read the raw config to tell "unset" from "false".
 	recordOverrides := adaptiveRDPRecordOverrides(d, len(list))
 
+	seenIDs := make(map[string]bool, len(list))
 	targets := make([]AdaptiveRDPTargetConfig, 0, len(list))
 	for i, item := range list {
 		m, ok := item.(map[string]interface{})
 		if !ok {
 			return AdaptiveRDPIntegrationConfiguration{}, errors.New("could not parse `targets` entry")
 		}
+		id := m["id"].(string)
+		if seenIDs[id] {
+			return AdaptiveRDPIntegrationConfiguration{}, fmt.Errorf("duplicate `targets` id %q: each target must have a unique id", id)
+		}
+		seenIDs[id] = true
 		targets = append(targets, AdaptiveRDPTargetConfig{
-			ID:       m["id"].(string),
+			ID:       id,
 			Name:     m["name"].(string),
 			Host:     m["host"].(string),
 			Port:     m["port"].(int),

--- a/internal/provider/integrations/adaptive_rdp_test.go
+++ b/internal/provider/integrations/adaptive_rdp_test.go
@@ -1,0 +1,140 @@
+package integrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func adaptiveRDPTestSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {Type: schema.TypeString, Optional: true},
+		"targets": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id":       {Type: schema.TypeString, Required: true},
+					"name":     {Type: schema.TypeString, Optional: true},
+					"host":     {Type: schema.TypeString, Required: true},
+					"port":     {Type: schema.TypeInt, Optional: true, Default: 3389},
+					"username": {Type: schema.TypeString, Required: true},
+					"password": {Type: schema.TypeString, Optional: true, Sensitive: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+					"record":   {Type: schema.TypeBool, Optional: true},
+				},
+			},
+		},
+	}
+}
+
+func TestSchemaToAdaptiveRDPIntegrationConfiguration_NoTargets(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, adaptiveRDPTestSchema(), map[string]interface{}{
+		"name": "rdp-fleet",
+	})
+
+	if _, err := SchemaToAdaptiveRDPIntegrationConfiguration(d); err == nil {
+		t.Fatal("expected an error when no targets are configured")
+	}
+}
+
+func TestSchemaToAdaptiveRDPIntegrationConfiguration_DuplicateID(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, adaptiveRDPTestSchema(), map[string]interface{}{
+		"name": "rdp-fleet",
+		"targets": []interface{}{
+			map[string]interface{}{"id": "server-1", "host": "10.0.0.5", "username": "admin"},
+			map[string]interface{}{"id": "server-1", "host": "10.0.0.6", "username": "admin"},
+		},
+	})
+
+	_, err := SchemaToAdaptiveRDPIntegrationConfiguration(d)
+	if err == nil {
+		t.Fatal("expected an error for duplicate target ids")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected a duplicate-id error, got: %v", err)
+	}
+}
+
+func TestSchemaToAdaptiveRDPIntegrationConfiguration_Success(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, adaptiveRDPTestSchema(), map[string]interface{}{
+		"name": "rdp-fleet",
+		"targets": []interface{}{
+			map[string]interface{}{"id": "server-1", "host": "10.0.0.5", "username": "admin"},
+			map[string]interface{}{"id": "server-2", "host": "10.0.0.6", "username": "admin"},
+		},
+	})
+
+	cfg, err := SchemaToAdaptiveRDPIntegrationConfiguration(d)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(cfg.Targets, "server-1") || !strings.Contains(cfg.Targets, "server-2") {
+		t.Fatalf("expected marshaled targets to contain both ids, got: %s", cfg.Targets)
+	}
+}
+
+// TestAdaptiveRDPRecordOverrides_TriState exercises the raw-config/cty
+// traversal that distinguishes an explicit `record = false` from an unset
+// `record` (which d.Get alone cannot do, since both collapse to false).
+// schema.TestResourceDataRaw does not populate GetRawConfig(), so the
+// ResourceData is built by hand here with a crafted RawConfig.
+func TestAdaptiveRDPRecordOverrides_TriState(t *testing.T) {
+	targetObj := func(id string, record cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"id":       cty.StringVal(id),
+			"name":     cty.NullVal(cty.String),
+			"host":     cty.StringVal("host"),
+			"port":     cty.NumberIntVal(3389),
+			"username": cty.StringVal("user"),
+			"password": cty.NullVal(cty.String),
+			"domain":   cty.NullVal(cty.String),
+			"record":   record,
+		})
+	}
+
+	rawConfig := cty.ObjectVal(map[string]cty.Value{
+		"targets": cty.ListVal([]cty.Value{
+			targetObj("explicit-true", cty.True),
+			targetObj("unset", cty.NullVal(cty.Bool)),
+			targetObj("explicit-false", cty.False),
+		}),
+	})
+
+	sm := schema.InternalMap(adaptiveRDPTestSchema())
+	d, err := sm.Data(nil, &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{},
+		RawConfig:  rawConfig,
+	})
+	if err != nil {
+		t.Fatalf("failed to build resource data: %v", err)
+	}
+
+	overrides := adaptiveRDPRecordOverrides(d, 3)
+
+	if overrides[0] == nil || *overrides[0] != true {
+		t.Errorf("expected index 0 (explicit true) to be *true, got %v", overrides[0])
+	}
+	if overrides[1] != nil {
+		t.Errorf("expected index 1 (unset) to be nil, got %v", *overrides[1])
+	}
+	if overrides[2] == nil || *overrides[2] != false {
+		t.Errorf("expected index 2 (explicit false) to be *false, got %v", overrides[2])
+	}
+}
+
+func TestAdaptiveRDPRecordOverrides_NoRawConfig(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, adaptiveRDPTestSchema(), map[string]interface{}{
+		"targets": []interface{}{
+			map[string]interface{}{"id": "server-1", "host": "10.0.0.5", "username": "admin"},
+		},
+	})
+
+	overrides := adaptiveRDPRecordOverrides(d, 1)
+	if overrides[0] != nil {
+		t.Errorf("expected nil override when raw config is unavailable, got %v", *overrides[0])
+	}
+}

--- a/templates/resources/resource.md.tmpl
+++ b/templates/resources/resource.md.tmpl
@@ -26,6 +26,7 @@ The `adaptive_resource` resource allows you to create and manage connections to 
 | `gcp` | Google Cloud Platform |
 | `kubernetes` | Kubernetes cluster |
 | `ssh` | SSH server |
+| `adaptive_rdp` | Windows RDP fleet — multiple targets, per-target credentials, in-browser access |
 | `okta` | Okta identity provider |
 | `onelogin` | OneLogin identity provider |
 | `jumpcloud` | JumpCloud directory |
@@ -147,6 +148,38 @@ resource "adaptive_resource" "ssh" {
   username = "admin"
   key      = file("~/.ssh/id_rsa")
   tags     = ["infrastructure"]
+}
+```
+
+### Adaptive RDP (Multi-Target Fleet)
+
+The `adaptive_rdp` type manages a fleet of Windows RDP hosts in a single resource. Each `targets` block is one host with its own credentials; users pick a target from the in-browser desktop picker. `password` is sensitive, `port` defaults to `3389`, and the optional `record` overrides the global session-recording setting per target (omit it to inherit the global setting).
+
+```terraform
+resource "adaptive_resource" "rdp_fleet" {
+  name = "rdp-fleet-01"
+  type = "adaptive_rdp"
+
+  targets {
+    id       = "server-1"
+    name     = "Windows Server 1"
+    host     = "10.0.0.5"
+    port     = 3389
+    username = "administrator"
+    password = var.win1_password
+  }
+
+  targets {
+    id       = "server-2"
+    name     = "Windows Server 2"
+    host     = "10.0.0.6"
+    username = "administrator"
+    password = var.win2_password
+    domain   = "CORP"
+    record   = true
+  }
+
+  tags = ["windows", "production"]
 }
 ```
 

--- a/templates/resources/resource.md.tmpl
+++ b/templates/resources/resource.md.tmpl
@@ -26,17 +26,22 @@ The `adaptive_resource` resource allows you to create and manage connections to 
 | `gcp` | Google Cloud Platform |
 | `kubernetes` | Kubernetes cluster |
 | `ssh` | SSH server |
+| `rdp_windows` | Windows server (single-target RDP) |
 | `adaptive_rdp` | Windows RDP fleet — multiple targets, per-target credentials, in-browser access |
 | `okta` | Okta identity provider |
+| `azureactivedirectory` | Azure Active Directory |
 | `onelogin` | OneLogin identity provider |
 | `jumpcloud` | JumpCloud directory |
 | `google` | Google Workspace |
+| `msteams` | Microsoft Teams |
 | `datadog` | Datadog monitoring |
 | `splunk` | Splunk logging |
 | `elasticsearch` | Elasticsearch |
+| `coralogix` | Coralogix logging |
+| `syslog` | Syslog server |
 | `rabbitmq` | RabbitMQ message broker |
 | `zerotier` | ZeroTier network |
-| `services` | Generic services |
+| `services` | Generic services (URL list) |
 | `customintegration` | Custom integration |
 
 ## Example Usage
@@ -151,6 +156,20 @@ resource "adaptive_resource" "ssh" {
 }
 ```
 
+### Windows Server (Single-Target RDP)
+
+```terraform
+resource "adaptive_resource" "windows" {
+  name     = "windows-server"
+  type     = "rdp_windows"
+  hostname = "windows.example.com"
+  port     = "3389"
+  username = "Administrator"
+  password = var.windows_password
+  tags     = ["infrastructure", "windows"]
+}
+```
+
 ### Adaptive RDP (Multi-Target Fleet)
 
 The `adaptive_rdp` type manages a fleet of Windows RDP hosts in a single resource. Each `targets` block is one host with its own credentials; users pick a target from the in-browser desktop picker. `password` is sensitive, `port` defaults to `3389`, and the optional `record` overrides the global session-recording setting per target (omit it to inherit the global setting).
@@ -197,6 +216,234 @@ resource "adaptive_resource" "snowflake" {
   schema    = "PUBLIC"
   role      = "ACCOUNTADMIN"
   tags      = ["analytics"]
+}
+```
+
+### CockroachDB
+
+```terraform
+resource "adaptive_resource" "cockroachdb" {
+  name          = "production-cockroachdb"
+  type          = "cockroachdb"
+  host          = "cockroach.example.com"
+  port          = "26257"
+  username      = "admin"
+  password      = var.cockroach_password
+  database_name = "defaultdb"
+  ssl_mode      = "verify-full"
+  root_cert     = file("ca.crt")
+  tags          = ["production", "database"]
+}
+```
+
+### ClickHouse
+
+```terraform
+resource "adaptive_resource" "clickhouse" {
+  name          = "analytics-clickhouse"
+  type          = "clickhouse"
+  host          = "clickhouse.example.com"
+  port          = "9440"
+  username      = "default"
+  password      = var.clickhouse_password
+  database_name = "analytics"
+  ssl_mode      = "require"
+  tags          = ["analytics"]
+}
+```
+
+### Services
+
+```terraform
+resource "adaptive_resource" "services" {
+  name = "internal-services"
+  type = "services"
+  urls = "https://api.internal.com,https://admin.internal.com,https://dashboard.internal.com"
+  tags = ["internal", "web"]
+}
+```
+
+### Okta
+
+```terraform
+resource "adaptive_resource" "okta" {
+  name          = "okta-sso"
+  type          = "okta"
+  domain        = "mycompany.okta.com"
+  client_id     = var.okta_client_id
+  client_secret = var.okta_client_secret
+  tags          = ["identity", "sso"]
+}
+```
+
+### Azure Active Directory
+
+```terraform
+resource "adaptive_resource" "azure_ad" {
+  name          = "azure-ad-integration"
+  type          = "azureactivedirectory"
+  domain        = "mycompany.onmicrosoft.com"
+  tenant_id     = var.azure_tenant_id
+  client_id     = var.azure_client_id
+  client_secret = var.azure_client_secret
+  tags          = ["identity", "azure"]
+}
+```
+
+### OneLogin
+
+```terraform
+resource "adaptive_resource" "onelogin" {
+  name              = "onelogin-sso"
+  type              = "onelogin"
+  domain            = "mycompany.onelogin.com"
+  client_id         = var.onelogin_client_id
+  client_secret     = var.onelogin_client_secret
+  api_client_id     = var.onelogin_api_client_id
+  api_client_secret = var.onelogin_api_client_secret
+  tags              = ["identity", "sso"]
+}
+```
+
+### JumpCloud
+
+```terraform
+resource "adaptive_resource" "jumpcloud" {
+  name          = "jumpcloud-directory"
+  type          = "jumpcloud"
+  domain        = "console.jumpcloud.com"
+  client_id     = var.jumpcloud_client_id
+  client_secret = var.jumpcloud_client_secret
+  api_token     = var.jumpcloud_api_key
+  tags          = ["identity", "directory"]
+}
+```
+
+### Google Workspace
+
+```terraform
+resource "adaptive_resource" "google_workspace" {
+  name          = "google-workspace"
+  type          = "google"
+  domain        = "mycompany.com"
+  client_id     = var.google_client_id
+  client_secret = var.google_client_secret
+  tags          = ["identity", "google"]
+}
+```
+
+### Datadog
+
+```terraform
+resource "adaptive_resource" "datadog" {
+  name       = "datadog-monitoring"
+  type       = "datadog"
+  dd_site    = "datadoghq.com"
+  dd_api_key = var.datadog_api_key
+  tags       = ["monitoring"]
+}
+```
+
+### Splunk
+
+```terraform
+resource "adaptive_resource" "splunk" {
+  name     = "splunk-logging"
+  type     = "splunk"
+  url      = "https://splunk.example.com:8088"
+  token_id = var.splunk_hec_token
+  tags     = ["logging"]
+}
+```
+
+### Elasticsearch
+
+```terraform
+resource "adaptive_resource" "elasticsearch" {
+  name     = "elasticsearch-cluster"
+  type     = "elasticsearch"
+  uri      = "https://elasticsearch.example.com:9200"
+  username = "elastic"
+  password = var.elasticsearch_password
+  index    = "logs"
+  tags     = ["logging", "search"]
+}
+```
+
+### Coralogix
+
+```terraform
+resource "adaptive_resource" "coralogix" {
+  name             = "coralogix-logging"
+  type             = "coralogix"
+  uri              = "https://api.coralogix.com"
+  private_key      = var.coralogix_private_key
+  application_name = "my-application"
+  sub_system_name  = "production"
+  tags             = ["logging"]
+}
+```
+
+### Syslog
+
+```terraform
+resource "adaptive_resource" "syslog" {
+  name     = "syslog-server"
+  type     = "syslog"
+  hostname = "syslog.example.com"
+  port     = "514"
+  protocol = "tcp"
+  tags     = ["logging"]
+}
+```
+
+### RabbitMQ
+
+```terraform
+resource "adaptive_resource" "rabbitmq" {
+  name     = "rabbitmq-broker"
+  type     = "rabbitmq"
+  uri      = "amqp://rabbitmq.example.com:5672"
+  username = "admin"
+  password = var.rabbitmq_password
+  tags     = ["messaging"]
+}
+```
+
+### Microsoft Teams
+
+```terraform
+resource "adaptive_resource" "msteams" {
+  name          = "teams-integration"
+  type          = "msteams"
+  tenant_id     = var.teams_tenant_id
+  client_id     = var.teams_app_id
+  client_secret = var.teams_app_key
+  tags          = ["collaboration"]
+}
+```
+
+### ZeroTier
+
+```terraform
+resource "adaptive_resource" "zerotier" {
+  name       = "zerotier-network"
+  type       = "zerotier"
+  network_id = "1234567890abcdef"
+  api_token  = var.zerotier_api_token
+  tags       = ["networking"]
+}
+```
+
+### Custom Integration
+
+```terraform
+resource "adaptive_resource" "custom" {
+  name                 = "custom-app"
+  type                 = "customintegration"
+  image                = "myregistry/myapp:latest"
+  service_account_name = "custom-sa"
+  tags                 = ["custom"]
 }
 ```
 


### PR DESCRIPTION
## Summary
- Adds a new `adaptive_rdp` integration type: a single `adaptive_resource` manages a fleet of Windows RDP hosts, each with its own `targets` block (id, host, port, username, password, domain, and an optional per-target `record` override that inherits a global recording setting when unset).
- Rejects duplicate `targets[].id` values instead of silently accepting them, since the backend looks targets up by id.
- Adds unit test coverage for the new integration, including the tri-state `record` cty-based parsing that previously had none.
- Restores ~18 integration example sections/type-table rows to `templates/resources/resource.md.tmpl` that a prior commit had only hand-added to the generated `docs/resources/resource.md` (never to the template) — this branch's `make docs` regeneration would otherwise have silently deleted them.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] `./scripts/dev-workflow.sh` against a live Adaptive workspace to exercise `terraform apply` with an `adaptive_rdp` resource end-to-end

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>